### PR TITLE
Fix venta creation request format

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -16,7 +16,11 @@ apiClient.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN);
     if (token) {
-      config.headers['x-token'] = token;
+      if (!config.headers) {
+        config.headers = {} as any;
+      }
+      (config.headers as Record<string, string>)['x-token'] = token;
+      (config.headers as Record<string, string>)['Authorization'] = `Bearer ${token}`;
     }
     return config;
   },

--- a/src/services/ventasService.ts
+++ b/src/services/ventasService.ts
@@ -33,48 +33,40 @@ export const createVenta = async (appointment: Appointment, metodoPago: string):
     throw new Error('No hay token de autenticación');
   }
 
-  // Preparar los datos como los espera la API (sin estructura envuelta)
-  const ventaData: any = {
-    usuario: {
-      _id: appointment.usuario._id,
-      nombre: appointment.usuario.nombre,
-      email: appointment.usuario.email
-    },
-    empresa: {
-      _id: appointment.empresa,
-      nombre: "LBJ" // TODO: obtener nombre real de la empresa
-    },
-    sucursal: {
-      _id: appointment.sucursal._id,
-      nombre: appointment.sucursal.nombre
-    },
-    profesional: {
-      _id: appointment.profesional._id,
-      nombre: appointment.profesional.nombre
-    },
+  const ventaData: VentaData = {
+    usuario: appointment.usuario._id,
+    empresa: appointment.empresa,
+    sucursal: appointment.sucursal._id,
+    profesional: appointment.profesional._id,
     fechaCita: appointment.fecha,
     importe: appointment.importe,
-    promocion: appointment.promocion.map((promocionId: string) => ({
-      _id: promocionId,
-      titulo: "Aleatorio o Barbero Junior" // TODO: mapear títulos reales
-    })),
-    servicios: appointment.servicios.map(servicio => ({
+    promocion: Array.isArray(appointment.promocion)
+      ? appointment.promocion.map((promo: any) => {
+          if (typeof promo === 'string') {
+            return promo;
+          }
+          if (promo && typeof promo === 'object' && '_id' in promo) {
+            return promo._id;
+          }
+          return promo;
+        })
+      : [],
+    servicios: appointment.servicios.map((servicio) => ({
       _id: servicio._id,
       nombre: servicio.nombre,
       precio: servicio.precio
     })),
-    variantes: appointment.variantes.map(variante => ({
+    variantes: appointment.variantes.map((variante) => ({
       _id: variante._id,
       nombre: variante.nombre
     })),
     productos: [],
-    metodoPago: metodoPago,
+    metodoPago,
     cita: appointment._id,
-    descuentos: appointment.descuentos,
-    fechaVenta: new Date().toISOString(),
-    creacion: new Date().toISOString(),
-    modificacion: new Date().toISOString()
+    descuentos: Array.isArray(appointment.descuentos) ? appointment.descuentos : [],
+    fechaVenta: new Date().toISOString()
   };
+
   try {
     const response = await apiClient.post('/ventas', ventaData, {
       headers: {


### PR DESCRIPTION
## Summary
- normalize the venta creation payload so the API receives identifiers instead of nested objects
- attach both the legacy `x-token` and a Bearer `Authorization` header to axios requests to keep authentication valid when completing payments

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cdce60e03c8329bb03d1d33b70bcc7