### PR TITLE
Ensure ventas keep bearer prefix in x-token header

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,39 @@
-import axios from 'axios';
+import axios, { AxiosHeaders } from 'axios';
 import { API_BASE_URL, STORAGE_KEYS } from '../utils/constants';
 import { Appointment } from '../types';
+
+const normalizeToken = (token: string) => {
+  const trimmed = token.trim();
+  const hasBearerPrefix = /^Bearer\s+/i.test(trimmed);
+
+  if (!trimmed) {
+    return { headerToken: '', bearerToken: '' };
+  }
+
+  const bearerToken = hasBearerPrefix ? trimmed : `Bearer ${trimmed}`;
+
+  return { headerToken: trimmed, bearerToken };
+};
+
+export const buildAuthHeaders = (token: string | null): Record<string, string> => {
+  if (!token) {
+    return {};
+  }
+
+  const { headerToken, bearerToken } = normalizeToken(token);
+
+  const headers: Record<string, string> = {};
+
+  if (headerToken) {
+    headers['x-token'] = headerToken;
+  }
+
+  if (bearerToken) {
+    headers.Authorization = bearerToken;
+  }
+
+  return headers;
+};
 
 // Create axios instance
 export const apiClient = axios.create({
@@ -14,10 +47,21 @@ export const apiClient = axios.create({
 // Request interceptor to add auth token
 apiClient.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN);
-    if (token) {
-      config.headers['x-token'] = token;
+    const storedToken =
+      localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN) ||
+      localStorage.getItem('exora_token');
+
+    const authHeaders = buildAuthHeaders(storedToken);
+
+    if (Object.keys(authHeaders).length > 0) {
+      const headers = AxiosHeaders.from(config.headers ?? {});
+      Object.entries(authHeaders).forEach(([key, value]) => {
+        headers.set(key, value);
+      });
+
+      config.headers = headers;
     }
+
     return config;
   },
   (error) => {

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -103,17 +103,22 @@ export class AuthService {
   static setToken(token: string): void {
     if (typeof window === 'undefined') return;
     localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, token);
+    localStorage.setItem('exora_token', token);
   }
 
   static getToken(): string | null {
     if (typeof window === 'undefined') return null;
-    return localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN);
+    return (
+      localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN) ||
+      localStorage.getItem('exora_token')
+    );
   }
 
   static removeToken(): void {
     if (typeof window === 'undefined') return;
     localStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
     localStorage.removeItem(STORAGE_KEYS.USER_DATA);
+    localStorage.removeItem('exora_token');
   }
 
   static isAuthenticated(): boolean {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -23,6 +23,7 @@ export const useAuthStore = create<AuthState>((set) => ({
 
         // Store session in localStorage
         localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, response.token);
+        localStorage.setItem('exora_token', response.token);
         localStorage.setItem(STORAGE_KEYS.USER_DATA, JSON.stringify(normalizedUser));
 
         set({
@@ -45,6 +46,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   logout: () => {
     AuthService.logout();
     localStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
+    localStorage.removeItem('exora_token');
     localStorage.removeItem(STORAGE_KEYS.USER_DATA);
 
     set({
@@ -57,7 +59,13 @@ export const useAuthStore = create<AuthState>((set) => ({
   },
 
   checkAuth: () => {
-    const token = localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN);
+    const storedToken = localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN);
+    const legacyToken = localStorage.getItem('exora_token');
+    const token = storedToken || legacyToken;
+
+    if (!storedToken && legacyToken) {
+      localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, legacyToken);
+    }
     const userData = localStorage.getItem(STORAGE_KEYS.USER_DATA);
     
     if (token && userData) {


### PR DESCRIPTION
## Summary
- keep the stored token value intact when attaching the legacy `x-token` header so the backend still accepts bearer-prefixed tokens
- continue deriving the Bearer-formatted Authorization header from the stored token to support both authentication mechanisms during sales

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cdce60e03c8329bb03d1d33b70bcc7