### PR TITLE
feat: allow swipe down to refresh

### DIFF
--- a/src/hooks/useSwipeGestureSimple.ts
+++ b/src/hooks/useSwipeGestureSimple.ts
@@ -87,9 +87,17 @@ export const useSwipeGestureSimple = ({
     if (disabled) return;
 
     if (!down) {
-      const shouldSwipe = Math.abs(mx) > SWIPE_THRESHOLD;
+      const absX = Math.abs(mx);
+      const absY = Math.abs(my);
 
-      if (shouldSwipe) {
+      const isVerticalPreference = absY > absX && absY > VERTICAL_SWIPE_THRESHOLD;
+
+      if (isVerticalPreference) {
+        handleVerticalSwipe(my);
+        return;
+      }
+
+      if (absX > SWIPE_THRESHOLD) {
         const isLeftSwipe = mx < 0;
 
         if (isAtEdge(isLeftSwipe)) {
@@ -98,9 +106,10 @@ export const useSwipeGestureSimple = ({
         }
 
         executeSwipeAnimation(isLeftSwipe);
-      } else {
-        handleVerticalSwipe(my);
+        return;
       }
+
+      handleVerticalSwipe(my);
     } else {
       handleDragFeedback(mx, my);
     }


### PR DESCRIPTION
## Summary
- detect when swipe gestures have a stronger vertical component and trigger the down-swipe handler
- fall back to the existing refresh handler when movement is mostly vertical while retaining horizontal transitions

## Testing
- npm run lint *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8b2a187c8329b542ba2ad29bc0ed